### PR TITLE
query 11 solved

### DIFF
--- a/line_items_per_invoice.sql
+++ b/line_items_per_invoice.sql
@@ -1,3 +1,3 @@
 SELECT COUNT(*), InvoiceId
 FROM InvoiceLine
-WHERE InvoiceId = 37
+GROUP BY InvoiceId


### PR DESCRIPTION
Line items per invoice